### PR TITLE
Initialize Yarn to allow ci tests to run

### DIFF
--- a/contrib/terraform-testing-infrastructure/README.md
+++ b/contrib/terraform-testing-infrastructure/README.md
@@ -335,6 +335,7 @@ following components will run on the `manager` node:
 
 - Apache ZooKeeper
 - Apache Hadoop NameNode
+- Apache Hadoop Yarn ResourceManager
 - Apache Accumulo Manager
 - Apache Accumulo Monitor
 - Apache Accumulo GarbageCollector
@@ -346,6 +347,7 @@ following components will run on the `manager` node:
 The following components will run on the `worker` nodes:
 
 - Apache Hadoop DataNode
+- Apache Hadoop Yarn NodeManager
 - Apache Accumulo TabletServer
 - Apache Accumulo Compactor(s)
 
@@ -389,14 +391,18 @@ Short Term access keys in your environment
 
 For an `aws` cluster, you can access the software configuration/management web pages here:
 - Hadoop NameNode: http://manager-main-default.${route53_zone}:9870
+- Yarn ResourceManager: http://manager-main-default.${route53_zone}:8088
 - Hadoop DataNode: http://worker#-main-default.${route53_zone}:9864
+- Yarn NodeManager: http://worker#-main-default.${route53_zone}:8042
 - Accumulo Monitor: http://manager-main-default.${route53_zone}:9995
 - Jaeger Tracing UI: http://manager-main-default.${route53_zone}:16686
 - Grafana: http://manager-main-default.${route53_zone}:3003
 
 For an `azure` cluster, you can access the software configuration/management web pages here:
 - Hadoop NameNode: http://manager-public-ip-address:9870
+- Yarn ResourceManager: http://manager-public-ip-address:8088
 - Hadoop DataNode: http://worker#-public-ip-address:9864
+- Yarn NodeManager: http://worker#-public-ip-address:8042
 - Accumulo Monitor: http://manager-public-ip-address:9995
 - Jaeger Tracing UI: http://manager-public-ip-address:16686
 - Grafana: http://manager-public-ip-address:3003

--- a/contrib/terraform-testing-infrastructure/modules/cloud-init-config/files/update-hosts-genders.sh
+++ b/contrib/terraform-testing-infrastructure/modules/cloud-init-config/files/update-hosts-genders.sh
@@ -10,22 +10,43 @@ fi
 HOSTS_ADDITIONS=$1
 GENDERS_ADDITIONS=$2
 
+begin_hosts_marker="##### BEGIN GENERATED HOSTS #####"
+end_hosts_marker="##### END GENERATED HOSTS #####"
+begin_genders_marker="##### BEGIN GENERATED GENDERS #####"
+end_genders_marker="##### END GENERATED GENDERS #####"
+
 # Update the hosts file locally
-sudo sed -ri '/^#+ BEGIN GENERATED HOSTS #+$/,/^#+ END GENERATED HOSTS #+$/d' /etc/hosts
-cat "$HOSTS_ADDITIONS" | sudo tee -a /etc/hosts > /dev/null
+# Wrap the supplied host additions with markers that we'll use to strip it back out.
+TMPHOSTS=/tmp/hosts$$
+cat > $TMPHOSTS <<EOF
+$begin_hosts_marker
+##### DO NOT EDIT THIS SECTION #####
+$(<"$HOSTS_ADDITIONS")
+$end_hosts_marker
+EOF
+# Strip out any previously applied hosts additiona, and then tack the new ones on to the end of /etc/hosts.
+sudo sed -ri '/^'"$begin_hosts_marker"'$/,/^'"$end_hosts_marker"'$/d' /etc/hosts
+cat "$TMPHOSTS" | sudo tee -a /etc/hosts > /dev/null
 
 # Update the genders file locally
-[[ -f /etc/genders ]] && sudo sed -ri '/^#+ BEGIN GENERATED GENDERS #+$/,/^#+ END GENERATED GENDERS #+$/d' /etc/genders
-cat "$GENDERS_ADDITIONS" | sudo tee -a /etc/genders > /dev/null
+TMPGENDERS=/tmp/genders$$
+cat > $TMPGENDERS <<EOF
+$begin_genders_marker
+$(<"$GENDERS_ADDITIONS")
+$end_genders_marker
+EOF
+[[ -f /etc/genders ]] && sudo sed -ri '/^'"$begin_genders_marker"'$/,/^'"$end_genders_marker"'$/d' /etc/genders
+cat "$TMPGENDERS" | sudo tee -a /etc/genders > /dev/null
 echo "Check genders file validity..."
 nodeattr -k
 
 # Now copy hosts updates to the workers and apply
-TMPFILE=/tmp/hosts$$
-pdcp -g worker "$HOSTS_ADDITIONS" $TMPFILE
-pdsh -S -g worker 'sudo sed -ri '"'"'/^#+ BEGIN GENERATED HOSTS #+$/,/^#+ END GENERATED HOSTS #+$/d'"'"' /etc/hosts'
-pdsh -S -g worker 'cat '$TMPFILE' | sudo tee -a /etc/hosts > /dev/null && rm -f $TMPFILE'
+pdcp -g worker $TMPHOSTS $TMPHOSTS
+pdsh -S -g worker 'sudo sed -ri '"'"'/^'"$begin_hosts_marker"'$/,/^'"$end_hosts_marker"'$/d'"'"' /etc/hosts'
+pdsh -S -g worker 'cat '$TMPHOSTS' | sudo tee -a /etc/hosts > /dev/null && rm -f $TMPHOSTS'
+rm -f $TMPHOSTS
 
 # Copy genders updates to the workers and apply
-pdcp -g worker /etc/genders /tmp/genders
-pdsh -S -g worker "sudo cp /tmp/genders /etc/genders && rm /tmp/genders"
+pdcp -g worker $TMPGENDERS $TMPGENDERS
+pdsh -S -g worker "sudo cp $TMPGENDERS /etc/genders && rm -f $TMPGENDERS"
+rm -f $TMPGENDERS

--- a/contrib/terraform-testing-infrastructure/modules/config-files/main.tf
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/main.tf
@@ -102,6 +102,12 @@ resource "local_file" "hadoop-hdfs-config" {
   content         = templatefile("${local.templates_dir}/hdfs-site.xml.tftpl", local.template_vars)
 }
 
+resource "local_file" "hadoop-yarn-config" {
+  filename        = "${local.conf_dir}/yarn-site.xml"
+  file_permission = "644"
+  content         = templatefile("${local.templates_dir}/yarn-site.xml.tftpl", local.template_vars)
+}
+
 resource "local_file" "accumulo-cluster-config" {
   filename        = "${local.conf_dir}/cluster.yaml"
   file_permission = "644"
@@ -136,6 +142,18 @@ resource "local_file" "datanode-systemd" {
   filename        = "${local.conf_dir}/hadoop-datanode.service"
   file_permission = "644"
   content         = templatefile("${local.templates_dir}/hadoop-datanode.service.tftpl", local.template_vars)
+}
+
+resource "local_file" "resourcemanager-systemd" {
+  filename        = "${local.conf_dir}/yarn-resourcemanager.service"
+  file_permission = "644"
+  content         = templatefile("${local.templates_dir}/yarn-resourcemanager.service.tftpl", local.template_vars)
+}
+
+resource "local_file" "nodemanager-systemd" {
+  filename        = "${local.conf_dir}/yarn-nodemanager.service"
+  file_permission = "644"
+  content         = templatefile("${local.templates_dir}/yarn-nodemanager.service.tftpl", local.template_vars)
 }
 
 resource "local_file" "zookeeper-systemd" {
@@ -181,12 +199,15 @@ resource "null_resource" "upload_config_files" {
     local_file.zookeeper-config,
     local_file.hadoop-core-config,
     local_file.hadoop-hdfs-config,
+    local_file.hadoop-yarn-config,
     local_file.accumulo-cluster-config,
     local_file.accumulo-properties-config,
     local_file.accumulo-client-properties-config,
     local_file.telegraf-config,
     local_file.namenode-systemd,
     local_file.datanode-systemd,
+    local_file.resourcemanager-systemd,
+    local_file.nodemanager-systemd,
     local_file.zookeeper-systemd,
     local_file.hadoop-bash-profile,
     local_file.hadoop-bashrc,

--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/genders.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/genders.tftpl
@@ -1,7 +1,4 @@
-##### BEGIN GENERATED GENDERS #####
-##### DO NOT EDIT BELOW THIS LINE #####
 manager    manager
 %{ for index, ip in worker_ips ~}
 worker${index}    worker
 %{ endfor ~}
-##### END GENERATED GENDERS #####

--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/hadoop_bashrc.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/hadoop_bashrc.tftpl
@@ -12,6 +12,6 @@ export M2_HOME=${software_root}/apache-maven/apache-maven-${maven_version}
 export ACCUMULO_JAVA_OPTS="-javaagent:${software_root}/accumulo/accumulo-${accumulo_version}/lib/opentelemetry-javaagent-1.7.1.jar -Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://${manager_ip}:14250 -Dtest.meter.registry.host=${manager_ip} -Dtest.meter.registry.port=8125"
 
 # User specific environment and startup programs
-PATH=$PATH:$HOME/.local/bin:$HOME/bin:$ZOOKEEPER_HOME/bin:$HADOOP_HOME/bin:$HADOOP_HOME/sbin:$ACCUMULO_HOME/bin
+PATH=$PATH:$HOME/.local/bin:$HOME/bin:$ZOOKEEPER_HOME/bin:$HADOOP_HOME/bin:$HADOOP_HOME/sbin:$ACCUMULO_HOME/bin:$M2_HOME/bin
 export PATH
 ulimit -n 32768

--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/hosts.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/hosts.tftpl
@@ -1,7 +1,4 @@
-##### BEGIN GENERATED HOSTS #####
-##### DO NOT EDIT BELOW THIS LINE #####
 ${manager_ip}	manager
 %{ for idx, ip in worker_ips ~}
 ${ip}	worker${idx}
 %{ endfor ~}
-##### END GENERATED HOSTS #####

--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/initialize_hadoop.sh.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/initialize_hadoop.sh.tftpl
@@ -3,30 +3,34 @@
 set -eo pipefail
 
 #
-# Copy local systemctl unit files into place and enable zookeeper and the namenode
+# Copy local systemctl unit files into place and enable zookeeper, the namenode, and the resourcemanager
 #
 sudo cp ${software_root}/conf/zookeeper.service /etc/systemd/system/zookeeper.service
 sudo cp ${software_root}/conf/hadoop-namenode.service /etc/systemd/system/hadoop-namenode.service
+sudo cp ${software_root}/conf/yarn-resourcemanager.service /etc/systemd/system/yarn-resourcemanager.service
 sudo systemctl daemon-reload
 sudo systemctl enable zookeeper
 sudo systemctl enable hadoop-namenode
+sudo systemctl enable yarn-resourcemanager
 
 #
-# Copy the datanode systemd unit file to each worker, and enable it there.
+# Copy the datanode and nodemanager systemd unit file to each worker, and enable them there.
 #
-pdcp -g worker ${software_root}/conf/hadoop-datanode.service /tmp/.
-pdsh -S -g worker "sudo cp /tmp/hadoop-datanode.service /etc/systemd/system/hadoop-datanode.service && rm -f /tmp/hadoop-datanode.service"
+pdcp -g worker ${software_root}/conf/hadoop-datanode.service ${software_root}/conf/yarn-nodemanager.service /tmp/.
+pdsh -S -g worker "sudo cp /tmp/{hadoop-datanode,yarn-nodemanager}.service /etc/systemd/system/. && rm -f /tmp/{hadoop-datanode,yarn-nodemanager}.service"
 pdsh -S -g worker sudo systemctl daemon-reload
-pdsh -S -g worker sudo systemctl enable hadoop-datanode
+pdsh -S -g worker sudo systemctl enable hadoop-datanode yarn-nodemanager
 
 #
 # Startup HDFS cluster
 # 1. Start zookeeper
 # 2. Format the namenode
 # 3. Start the namenode
-# 4. Start datanodes on the worker nodes
+# 4. Start the resource manager
+# 5. Start datanodes and nodemanagers on the worker nodes
 #
 sudo systemctl start zookeeper
 hdfs namenode -format
 sudo systemctl start hadoop-namenode
-pdsh -S -g worker 'sudo systemctl start hadoop-datanode'
+sudo systemctl start yarn-resourcemanager
+pdsh -S -g worker 'sudo systemctl start hadoop-datanode yarn-nodemanager'

--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/install_sw.sh.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/install_sw.sh.tftpl
@@ -21,7 +21,8 @@ fi
 if [ ! -d ${software_root}/apache-maven/apache-maven-${maven_version} ]; then
   mkdir -p ${software_root}/apache-maven
   tar zxf $MVN_SRC -C ${software_root}/apache-maven
-  cat << 'END' >> ${software_root}/apache-maven/settings.xml
+  [ -d ~/.m2 ] || mkdir ~/.m2
+  cat << 'END' >> ~/.m2/settings.xml
   <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
       <localRepository>${software_root}/apache-maven/repository</localRepository>
@@ -75,7 +76,7 @@ else
   git clone ${accumulo_repo} accumulo-repo
   cd accumulo-repo
   git checkout ${accumulo_branch_name}
-  ${software_root}/apache-maven/apache-maven-${maven_version}/bin/mvn -s ${software_root}/apache-maven/settings.xml -ntp clean package -DskipTests -DskipITs
+  ${software_root}/apache-maven/apache-maven-${maven_version}/bin/mvn -ntp clean package -DskipTests -DskipITs
   mkdir -p ${software_root}/accumulo
   tar zxf assemble/target/accumulo-${accumulo_version}-bin.tar.gz -C ${software_root}/accumulo
 fi
@@ -118,7 +119,7 @@ else
   git clone ${accumulo_testing_repo} accumulo-testing-repo
   cd accumulo-testing-repo
   git checkout ${accumulo_testing_branch_name}
-  ${software_root}/apache-maven/apache-maven-${maven_version}/bin/mvn -s ${software_root}/apache-maven/settings.xml -ntp clean package -DskipTests -DskipITs
+  ${software_root}/apache-maven/apache-maven-${maven_version}/bin/mvn -ntp clean package -DskipTests -DskipITs
 fi
 
 #
@@ -127,11 +128,17 @@ fi
 cp ${software_root}/conf/zoo.cfg ${software_root}/zookeeper/apache-zookeeper-${zookeeper_version}-bin/conf/zoo.cfg
 cp ${software_root}/conf/hdfs-site.xml ${software_root}/hadoop/hadoop-${hadoop_version}/etc/hadoop/hdfs-site.xml
 cp ${software_root}/conf/core-site.xml ${software_root}/hadoop/hadoop-${hadoop_version}/etc/hadoop/core-site.xml
+cp ${software_root}/conf/yarn-site.xml ${software_root}/hadoop/hadoop-${hadoop_version}/etc/hadoop/yarn-site.xml
 cp ${software_root}/conf/cluster.yaml ${software_root}/accumulo/accumulo-${accumulo_version}/conf/cluster.yaml
 cp ${software_root}/conf/accumulo.properties ${software_root}/accumulo/accumulo-${accumulo_version}/conf/accumulo.properties
 cp ${software_root}/conf/accumulo-client.properties ${software_root}/accumulo/accumulo-${accumulo_version}/conf/accumulo-client.properties
 mkdir -p ${software_root}/telegraf/conf
 cp ${software_root}/conf/telegraf.conf ${software_root}/telegraf/conf/.
+
+# Update configuration properties for accumulo-testing
+defaultFS=$(hdfs getconf -confKey fs.defaultFS)
+sed -ri "s|^test.common.hdfs.root=.*$|test.common.hdfs.root=$${defaultFS}|" $SOURCES_DIR/accumulo-testing-repo/conf/accumulo-testing.properties
+sed -ri "s|^test.common.yarn.resource.manager=.*$|test.common.yarn.resource.manager=${manager_ip}|" $SOURCES_DIR/accumulo-testing-repo/conf/accumulo-testing.properties
 
 #
 # Make directories that will be needed for metrics collection

--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/yarn-nodemanager.service.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/yarn-nodemanager.service.tftpl
@@ -1,0 +1,18 @@
+[Unit]
+Description=Yarn NodeManager start/stop
+After=hadoop-datanode.service
+
+[Service]
+Environment=JAVA_HOME=${java_home}
+Environment=YARN_HOME=${software_root}/hadoop/hadoop-${hadoop_version}
+Environment=HADOOP_LOG_DIR=${hadoop_dir}/logs
+User=hadoop
+Group=hadoop
+Type=oneshot
+ExecStart=${software_root}/hadoop/hadoop-${hadoop_version}/bin/yarn --daemon start nodemanager
+ExecStop=${software_root}/hadoop/hadoop-${hadoop_version}/bin/yarn --daemon stop nodemanager
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+

--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/yarn-resourcemanager.service.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/yarn-resourcemanager.service.tftpl
@@ -1,0 +1,18 @@
+[Unit]
+Description=Yarn ResourceManager start/stop
+After=hadoop-namenode.service
+
+[Service]
+Environment=JAVA_HOME=${java_home}
+Environment=YARN_HOME=${software_root}/hadoop/hadoop-${hadoop_version}
+Environment=HADOOP_LOG_DIR=${hadoop_dir}/logs
+User=hadoop
+Group=hadoop
+Type=oneshot
+ExecStart=${software_root}/hadoop/hadoop-${hadoop_version}/bin/yarn --daemon start resourcemanager
+ExecStop=${software_root}/hadoop/hadoop-${hadoop_version}/bin/yarn --daemon stop resourcemanager
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+

--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/yarn-site.xml.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/yarn-site.xml.tftpl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>yarn.resourcemanager.hostname</name>
+    <value>${manager_ip}</value>
+  </property>
+  <property>
+    <name>yarn.nodemanager.aux-services</name>
+    <value>mapreduce_shuffle</value>
+  </property>
+</configuration>
+


### PR DESCRIPTION
* Add systemd unit files for resourcemanager and nodemanagers that are
  enabled and started after HDFS.
* Add a minimal yarn-site.xml configuration that enables MapReduce and
  names the resource manager.
* Update the bashrc file to include maven in the path
* Move maven settings.xml file to hadoop's ~/.m2 dir
* Modify the accumulo-testing repo's conf file to name the
  resourcemanager host and HDFS default.
* Modify initial cluster setup script to move hosts and genders marker
  lines from the template into the update script to consolidate logic.