### PR TITLE
Update AWS shared_state to gen S3 bucket

### DIFF
--- a/contrib/terraform-testing-infrastructure/shared_state/aws/main.tf
+++ b/contrib/terraform-testing-infrastructure/shared_state/aws/main.tf
@@ -8,12 +8,13 @@ terraform {
 }
 
 provider "aws" {
-  region = "us-east-1"
+  region = var.region
 }
 
 resource "aws_s3_bucket" "terraform_state" {
-  bucket = "accumulo-testing-tf-state"
-  acl    = "private"
+  bucket        = var.bucket
+  acl           = var.bucket_acl
+  force_destroy = var.bucket_force_destroy
   # Enable versioning so we can see the full revision history of our
   # state files
   versioning {
@@ -33,11 +34,15 @@ resource "aws_s3_bucket" "terraform_state" {
 }
 
 resource "aws_dynamodb_table" "terraform_locks" {
-  name         = "accumulo-testing-tf-locks"
+  name         = var.dynamodb_table_name
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "LockID"
   attribute {
     name = "LockID"
     type = "S"
   }
+}
+
+output "bucket_name" {
+  value = aws_s3_bucket.terraform_state.id
 }

--- a/contrib/terraform-testing-infrastructure/shared_state/aws/variables.tf
+++ b/contrib/terraform-testing-infrastructure/shared_state/aws/variables.tf
@@ -1,0 +1,33 @@
+variable "bucket" {
+  default     = ""
+  type        = string
+  description = "S3 bucket name for storing shared state. If not supplied, a name will be generated."
+}
+
+variable "bucket_acl" {
+  default     = "private"
+  type        = string
+  description = "The ACL to use for the S3 bucket. Defaults to private."
+  validation {
+    condition     = contains(["private", "public-read", "public-read-write", "aws-exec-read", "authenticated-read", "log-delivery-write"], var.bucket_acl)
+    error_message = "The value of bucket_acl must be one of private, public-read, public-read-write, aws-exec-read, authenticated-read, or log-delivery-write."
+  }
+}
+
+variable "bucket_force_destroy" {
+  default     = false
+  type        = bool
+  description = "If true, upon terraform destroy, the bucket will be deleted even if it is not empty."
+}
+
+variable "region" {
+  type        = string
+  default     = "us-east-1"
+  description = "AWS region to use for S3 bucket."
+}
+
+variable "dynamodb_table_name" {
+  default     = "accumulo-testing-tf-locks"
+  type        = string
+  description = "DynamoDB table name for storing shared state."
+}


### PR DESCRIPTION
* Add variables to the AWS shared_state terraform configuration. These
  variables can be used to override the S3 configuration of the shared
  state.
* When the S3 bucket name is not supplied, the aws_s3_bucket resource
  generates a name. Return the bucket name (either the user-supplied
  name or the generate name in the bucket_name output.
* Update README to indicate how to use the new variables for AWS shared
  state.
* Update README for setting up SOCKS proxy for accessing an Azure
  cluster.