### PR TITLE
Monitoring stack improvements

### DIFF
--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/initialize_accumulo.sh.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/initialize_accumulo.sh.tftpl
@@ -33,7 +33,7 @@ sudo systemctl enable telegraf
 sudo systemctl start telegraf
 
 pdcp -g worker ${software_root}/conf/telegraf.conf /tmp/.
-pdsh -S -g worker "sudo cp /tmp/telegraf.conf /etc/telegraf/telegraf.conf && rm -f /tmp/telegraf.conf"
+pdsh -S -g worker sudo mv /tmp/telegraf.conf /etc/telegraf/telegraf.conf
 pdsh -S -g worker sudo systemctl enable telegraf
 pdsh -S -g worker sudo systemctl start telegraf
 

--- a/contrib/terraform-testing-infrastructure/timely-grafana/Dockerfile
+++ b/contrib/terraform-testing-infrastructure/timely-grafana/Dockerfile
@@ -20,46 +20,60 @@
 FROM redhat/ubi8 as builder
 COPY settings.xml /tmp/settings.xml
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk
-RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
-    dnf install -y java-11-openjdk-devel git wget collectd collectd-java && \
-    cd /opt && \
+
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+
+RUN dnf install -y java-11-openjdk-devel git wget collectd collectd-java
+
+RUN cd /opt && \
     wget https://dlcdn.apache.org/maven/maven-3/3.9.7/binaries/apache-maven-3.9.7-bin.tar.gz && \
-    tar zxf apache-maven-3.9.7-bin.tar.gz && \
-    cd /opt && \
+    tar zxf apache-maven-3.9.7-bin.tar.gz
+
+RUN cd /opt && \
     git clone https://github.com/NationalSecurityAgency/datawave-utils.git datawave-utils && \
     cd datawave-utils/code-style && \
     mv pom.xml pom.xml.bak && \
     sed "s/1-SNAPSHOT/0/" pom.xml.bak > pom.xml && \
-    /opt/apache-maven-3.9.7/bin/mvn -s /tmp/settings.xml clean install && \
-    cd /opt && \
+    /opt/apache-maven-3.9.7/bin/mvn -s /tmp/settings.xml clean install
+
+RUN cd /opt && \
     git clone https://github.com/NationalSecurityAgency/datawave-in-memory-accumulo.git datawave-in-memory-accumulo && \
     cd datawave-in-memory-accumulo && \
     git checkout accumulo4 && \
-    /opt/apache-maven-3.9.7/bin/mvn -s /tmp/settings.xml clean install && \
-    cd /opt && \
+    /opt/apache-maven-3.9.7/bin/mvn -s /tmp/settings.xml clean install
+
+RUN cd /opt && \
     git clone https://github.com/NationalSecurityAgency/timely.git timely && \
     cd timely && \
     git checkout accumulo4 && \
-    /opt/apache-maven-3.9.7/bin/mvn -s /tmp/settings.xml clean package -Pcollectd -DskipTests && \
-    dnf clean all && \
+    /opt/apache-maven-3.9.7/bin/mvn -s /tmp/settings.xml clean package -Pcollectd -DskipTests
+
+RUN dnf clean all && \
     rm -rf /var/cache/dnf
 
 FROM redhat/ubi8
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk TIMELY_VERSION="3.0.0-SNAPSHOT"
+
 COPY --from=builder /opt/timely/collectd-timely-plugin/target/collectd-timely-plugin-${TIMELY_VERSION}.jar /opt/timely/collectd-timely-plugin.jar
 COPY --from=builder /opt/timely/server/target/timely-server-${TIMELY_VERSION}-dist.tar.gz /tmp/timely-server-dist.tar.gz
 COPY --from=builder /opt/timely/grafana/target/timely-app-${TIMELY_VERSION}-dist.tar.gz /var/lib/grafana/plugins/timely-app-dist.tar.gz
-RUN dnf install -y java-11-openjdk-devel && \
-    dnf install -y https://dl.grafana.com/enterprise/release/grafana-enterprise-8.2.7-1.x86_64.rpm && \
-    cd /var/lib/grafana/plugins/ && \
+
+RUN dnf install -y java-11-openjdk-devel
+
+RUN dnf install -y https://dl.grafana.com/enterprise/release/grafana-enterprise-8.2.7-1.x86_64.rpm
+
+RUN cd /var/lib/grafana/plugins/ && \
     tar zxf timely-app-dist.tar.gz && \
-    rm timely-app-dist.tar.gz && \
-    mkdir -p /opt/timely && \
+    rm timely-app-dist.tar.gz
+
+RUN mkdir -p /opt/timely && \
     cd /opt/timely && \
     tar zxf /tmp/timely-server-dist.tar.gz --strip-components=1 && \
-    rm /tmp/timely-server-dist.tar.gz && \
-    dnf clean all && \
+    rm /tmp/timely-server-dist.tar.gz
+
+RUN dnf clean all && \
     rm -rf /var/cache/dnf
+
 COPY entrypoint.sh /opt/entrypoint.sh
 EXPOSE 3000/tcp 4242/tcp 4243/tcp 4244/tcp 4245/udp
 ENTRYPOINT ["/opt/entrypoint.sh"]

--- a/contrib/terraform-testing-infrastructure/timely-grafana/Dockerfile
+++ b/contrib/terraform-testing-infrastructure/timely-grafana/Dockerfile
@@ -21,9 +21,10 @@ FROM redhat/ubi8 as builder
 COPY settings.xml /tmp/settings.xml
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk
 
-RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-
-RUN dnf install -y java-11-openjdk-devel git wget collectd collectd-java
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
+    dnf install -y java-11-openjdk-devel git wget collectd collectd-java && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
 RUN cd /opt && \
     wget https://dlcdn.apache.org/maven/maven-3/3.9.7/binaries/apache-maven-3.9.7-bin.tar.gz && \
@@ -46,32 +47,20 @@ RUN cd /opt && \
     git clone https://github.com/NationalSecurityAgency/timely.git timely && \
     cd timely && \
     git checkout accumulo4 && \
-    /opt/apache-maven-3.9.7/bin/mvn -s /tmp/settings.xml clean package -Pcollectd -DskipTests
-
-RUN dnf clean all && \
-    rm -rf /var/cache/dnf
+    /opt/apache-maven-3.9.7/bin/mvn -s /tmp/settings.xml clean package -Pcollectd -DskipTests && \
+    tar zxf server/target/timely-server-${TIMELY_VERSION}-dist.tar.gz --strip-components=1 -C /tmp/timely-server && \
+    tar zxf grafana/target/timely-app-${TIMELY_VERSION}-dist.tar.gz -C /tmp/timely-grafana
 
 FROM redhat/ubi8
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk TIMELY_VERSION="3.0.0-SNAPSHOT"
 
 COPY --from=builder /opt/timely/collectd-timely-plugin/target/collectd-timely-plugin-${TIMELY_VERSION}.jar /opt/timely/collectd-timely-plugin.jar
-COPY --from=builder /opt/timely/server/target/timely-server-${TIMELY_VERSION}-dist.tar.gz /tmp/timely-server-dist.tar.gz
-COPY --from=builder /opt/timely/grafana/target/timely-app-${TIMELY_VERSION}-dist.tar.gz /var/lib/grafana/plugins/timely-app-dist.tar.gz
+COPY --from=builder /tmp/timely-server /opt/timely
+COPY --from=builder /tmp/timely-grafana /var/lib/grafana/plugins/timely-app
 
-RUN dnf install -y java-11-openjdk-devel
-
-RUN dnf install -y https://dl.grafana.com/enterprise/release/grafana-enterprise-8.2.7-1.x86_64.rpm
-
-RUN cd /var/lib/grafana/plugins/ && \
-    tar zxf timely-app-dist.tar.gz && \
-    rm timely-app-dist.tar.gz
-
-RUN mkdir -p /opt/timely && \
-    cd /opt/timely && \
-    tar zxf /tmp/timely-server-dist.tar.gz --strip-components=1 && \
-    rm /tmp/timely-server-dist.tar.gz
-
-RUN dnf clean all && \
+RUN dnf install -y java-11-openjdk-devel && \
+    dnf install -y https://dl.grafana.com/enterprise/release/grafana-enterprise-8.2.7-1.x86_64.rpm && \
+    dnf clean all && \
     rm -rf /var/cache/dnf
 
 COPY entrypoint.sh /opt/entrypoint.sh

--- a/contrib/terraform-testing-infrastructure/timely-grafana/README.md
+++ b/contrib/terraform-testing-infrastructure/timely-grafana/README.md
@@ -30,7 +30,7 @@ using the OpenTSDB output plugin.
 
 ## Deployment
 
-1. Run `build-image.sh`, after this runs the timely jar files will be copied out
+1. Run `build-image.sh`, after this runs, the timely jar files will be copied out
    of the Docker image and put into the `build_output` directory.
 2. Copy the timely jar files from the `build_output` directory to `$ACCUMULO_HOME/lib`
 3. Add the following to `accumulo.properties':


### PR DESCRIPTION
Some small changes I noticed.

For the Dockerfile changes, I split up the long chained commands into a few more `RUN` commands for increased readability and maintainability. This does add more layers but I think its worth the small size diff in the resulting image (1.19GB vs 1.24GB). I also moved the tar extraction into the builder phase and just copied the result into the final stage.